### PR TITLE
Improve formatting of | after def and new line after |

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,6 @@ class NewLineIndentProvider implements OnTypeFormattingEditProvider {
 	}
 
 	indentForDefOrType(document: TextDocument, position: Position): ProviderResult<TextEdit[]> | null {
-		const prevLine = document.lineAt(position.line - 1)
 		const d = this.matchDefOrType(document.lineAt(position.line - 1))
 		if (!d) return
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,29 +9,51 @@ import {
 	Range,
 	Position,
 	ProviderResult,
+	TextLine,
 } from 'vscode';
 
 class InsertOrDeleteBarProvider implements OnTypeFormattingEditProvider {
+  matchDef(line: TextLine): RegExpMatchArray | null {
+		return line.text.match(/^(\s*)(def [^:]+):/)
+	}
+
+	matchBar(line: TextLine): RegExpMatchArray | null {
+		return line.text.match(/^(\s*\|\s*)$/)
+	}
+
+	formatBarAfterDef(document: TextDocument, position: Position): ProviderResult<TextEdit[]> | null {
+		const prevLine = document.lineAt(position.line - 1)
+		const def = this.matchDef(document.lineAt(position.line - 1))
+		if (!def) return
+
+		const indentSize = def[2].length;
+		const insertBar = TextEdit.insert(position, ' '.repeat(indentSize) + '| ')
+		return Promise.resolve([insertBar])
+	}
+
+	formatLineAfterBar(document: TextDocument, position: Position): ProviderResult<TextEdit[]> | null {
+		const prevLine = document.lineAt(position.line - 1)
+		const bar = this.matchBar(prevLine)
+		if (!bar) return
+
+		const prevPrevLine = document.lineAt(position.line - 2)
+		const def = this.matchDef(prevPrevLine)
+		if (!def) return
+
+		const deleteEmptyType = TextEdit.delete(prevLine.range)
+		const indentRange = document.lineAt(position.line).range
+		const deleteIndent = TextEdit.delete(indentRange)
+		const insertIndent = TextEdit.insert(new Position(position.line, 0), ' '.repeat(def[1].length))
+
+		return Promise.resolve([deleteEmptyType, deleteIndent, insertIndent])
+	}
+
 	provideOnTypeFormattingEdits(document: TextDocument, position: Position, ch: string, options: FormattingOptions, token: CancellationToken): ProviderResult<TextEdit[]> {
 		if (document.lineAt(position.line).text.substring(position.character).length) {
 			return
 		}
 
-		const prevLine = document.lineAt(position.line - 1)
-		const def = prevLine.text.match(/^(\s*def [^:]+):/)
-		if (def) {
-			const indentSize = def[1].length - options.tabSize;
-			const insertBar = TextEdit.insert(position, ' '.repeat(indentSize) + '| ')
-			return Promise.resolve([insertBar])
-		}
-
-		if (/^(\s*\|\s*)$/.test(prevLine.text)) {
-			const deleteEmptyType = TextEdit.delete(prevLine.range)
-			const indentRange = document.lineAt(position.line).range
-			const deleteIndent = TextEdit.delete(indentRange)
-			const insertIndent = TextEdit.insert(new Position(position.line, 0), ' '.repeat(options.tabSize))
-			return Promise.resolve([deleteEmptyType, deleteIndent, insertIndent])
-		}
+		return this.formatBarAfterDef(document, position) || this.formatLineAfterBar(document, position)
 	}
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -72,8 +72,6 @@ class NewLineIndentProvider implements OnTypeFormattingEditProvider {
 		}
 
 		return this.indentForDefOrType(document, position) || this.outdentToMember(document, position)
-
-		return
 	}	
 }
 


### PR DESCRIPTION
This PR is to improve the formatting `|` after method definition, and new line after line only with `|`.

The position of `|` inserted after method definition.

```rbs
class Foo
  class Bar
    def foo: () -> Test# ⤵️ Newline here
         |             # This is the current vertical bar position.
           |           # This is the expected vertical bar position.
  end
end
```

The text indent after `|` line.

```rbs
class Foo
  class Bar
    def foo: () -> Test
           |# ⤵️ Newline here
  ⬅️ Here is the cursor goes currently.
    ⬅️ Here is the expected cursor position.
  end
end
```